### PR TITLE
Deck class and tests

### DIFF
--- a/src/Deck.js
+++ b/src/Deck.js
@@ -1,0 +1,11 @@
+class Deck {
+  constructor(cards) {
+    this.cards = cards || [];
+  }
+
+  countCards() {
+    return this.cards.length || 0
+  }
+}
+
+module.exports = Deck;

--- a/test/Card-test.js
+++ b/test/Card-test.js
@@ -21,6 +21,10 @@ describe('Card', () => {
     expect(card).to.be.an.instanceof(Card);
   }); 
 
+  it('should have an id number', () => {
+    expect(card.id).to.equal(1);
+  });
+
   it('should store a question', () => {
     expect(card.question).to.equal('What allows you to define a set of related information using key-value pairs?');
   });  

--- a/test/Deck-test.js
+++ b/test/Deck-test.js
@@ -1,0 +1,46 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+const Card = require('../src/Card');
+const Deck = require('../src/Deck');
+
+describe('Deck', () => {
+
+  let card1;
+  let card2;
+  let card3;
+  let deck;
+
+  beforeEach(() => {
+
+    card1 = new Card(1, 'How does JS combine different datatypes?', ['it never does', 'magic', 'type coercion'], 'type coercion');
+
+    card2 = new Card(2, 'When does hoisting occur?', ['in the execution phase', 'in the creation phase', 'when sails need raising'], 'in the creation phase');
+
+    card3 = new Card(3, 'When should we use dot notation?', ['when we know the exact, unchanging key name', 'never', 'always'], 'When we know the exact, unchanging key name');
+
+    deck = new Deck([card1, card2, card3]);
+
+  });
+
+  it('should be a function', () => {
+    expect(Deck).to.be.a('function');
+  });
+
+  it('should be an instance of Deck', () => {
+    expect(deck).to.be.an.instanceOf(Deck);
+  });
+
+  it('should hold cards', () => {
+    expect(deck.cards).to.deep.equal([card1, card2, card3]);
+  });
+
+  it('should hold instantiated cards', () => {
+    expect(deck.cards[0].correctAnswer).to.equal('type coercion');
+  });
+
+  it('should be able to count cards in the deck', () => {
+    let numCards = deck.countCards();
+    expect(numCards).to.equal(3);
+  });
+});

--- a/test/Deck-test.js
+++ b/test/Deck-test.js
@@ -43,4 +43,10 @@ describe('Deck', () => {
     let numCards = deck.countCards();
     expect(numCards).to.equal(3);
   });
+
+  it('should be able to count cards in the deck', () => {
+    let deck = new Deck();
+    let numCards = deck.countCards();
+    expect(numCards).to.equal(0);
+  });
 });

--- a/test/Turn-test.js
+++ b/test/Turn-test.js
@@ -39,7 +39,7 @@ describe('Turn', () => {
     expect(turn.card).to.be.an.instanceOf(Card);
   });
 
-  it('should be able to return the guess guess made by the user', () => {
+  it('should be able to return the guess made by the user', () => {
     const turn = new Turn('in the creation phase', card2);
     turn.returnGuess();
     expect(turn.guess).to.equal('in the creation phase');
@@ -63,6 +63,12 @@ describe('Turn', () => {
     const turn = new Turn('type coercion', card1);
     turn.evaluateGuess();
     expect(turn.eval).to.equal(true);
+  });
+
+  it('should also evaluate an incorrect answer', () => {
+    const turn = new Turn('magic', card1);
+    turn.evaluateGuess();
+    expect(turn.eval).to.equal(false);
   });
 
   it('should give a user feedback reflecting a correct guess', () => {


### PR DESCRIPTION
#### What is the change?
Builds out structure for the Deck class in Deck.js.
Adds and passes tests in Deck-test.js.

#### What does it fix?
Creates Deck class and passes corresponding test suite.

#### Is this a fix or a feature? 
feature

#### Where should the reviewer start?
Line 1 in Deck.js,
Line 1 in Deck-test.js

#### How should this be tested?
run npm test in terminal to confirm that tests pass as expected.

#### Any relevant tickets?
#8 , #9 
